### PR TITLE
Fix for typo 'server_type' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Directory Access Protocol server:
 ```
 eloquent-ldap.enabled=true
 eloquent-ldap.debug=false
-eloquent-ldap.server_type=ldap
+eloquent-ldap.server_type=LDAP
 eloquent-ldap.create_accounts=true
 eloquent-ldap.replicate_group_membership=false
 eloquent-ldap.resync_on_login=false


### PR DESCRIPTION
In README.md example for LDAP connection variable 'server_type' should be 'LDAP' rather than 'ldap' because in EloquentLDAPUserProvider https://github.com/sroutier/eloquent-ldap/blob/b3cb788bf039dcfbf7da914fc3dcdae74c47561f/src/Providers/EloquentLDAPUserProvider.php#L613
 you are comparing this value against uppercase 'LDAP'. 
Wasted a bit of time trying to figure out problem with LDAP authorization caused by this inconsistency.
  